### PR TITLE
Add removed tests from `unsafe-expect`

### DIFF
--- a/test-cases/unsafe-expect/unsafe-expect-1/vulnerable-example/src/lib.rs
+++ b/test-cases/unsafe-expect/unsafe-expect-1/vulnerable-example/src/lib.rs
@@ -68,4 +68,20 @@ mod tests {
         let balance = client.balance_of(&contract_id);
         assert_eq!(TOTAL_SUPPLY, balance.unwrap());
     }
+
+    #[test]
+    #[should_panic(expected = "could not get balance")]
+    fn balance_of_expect_works() {
+        // Given
+        let env = Env::default();
+        let contract_id = env.register_contract(None, UnsafeExpect);
+        let client = UnsafeExpectClient::new(&env, &contract_id);
+
+        // When - Balance not set
+
+        // Then
+        let _balance = client.balance_of(&contract_id);
+
+        // Test should panic
+    }
 }

--- a/test-cases/unsafe-expect/unsafe-expect-2/vulnerable-example/src/lib.rs
+++ b/test-cases/unsafe-expect/unsafe-expect-2/vulnerable-example/src/lib.rs
@@ -66,4 +66,20 @@ mod tests {
         let balance = client.balance_of(&contract_id);
         assert_eq!(TOTAL_SUPPLY, balance.unwrap());
     }
+
+    #[test]
+    #[should_panic(expected = "could not get balance")]
+    fn balance_of_expect_works() {
+        // Given
+        let env = Env::default();
+        let contract_id = env.register_contract(None, UnsafeExpect);
+        let client = UnsafeExpectClient::new(&env, &contract_id);
+
+        // When - Balance not set
+
+        // Then
+        let _balance = client.balance_of(&contract_id);
+
+        // Test should panic
+    }
 }

--- a/test-cases/unsafe-expect/unsafe-expect-3/vulnerable-example/src/lib.rs
+++ b/test-cases/unsafe-expect/unsafe-expect-3/vulnerable-example/src/lib.rs
@@ -66,4 +66,20 @@ mod tests {
         let balance = client.balance_of(&contract_id);
         assert_eq!(TOTAL_SUPPLY, balance.unwrap());
     }
+
+    #[test]
+    #[should_panic(expected = "could not get balance")]
+    fn balance_of_expect_works() {
+        // Given
+        let env = Env::default();
+        let contract_id = env.register_contract(None, UnsafeExpect);
+        let client = UnsafeExpectClient::new(&env, &contract_id);
+
+        // When - Balance not set
+
+        // Then
+        let _balance = client.balance_of(&contract_id);
+
+        // Test should panic
+    }
 }

--- a/test-cases/unsafe-expect/unsafe-expect-4/vulnerable-example/src/lib.rs
+++ b/test-cases/unsafe-expect/unsafe-expect-4/vulnerable-example/src/lib.rs
@@ -74,4 +74,20 @@ mod tests {
         assert_eq!(TOTAL_SUPPLY, balances.0);
         assert_eq!(TOTAL_SUPPLY, balances.1);
     }
+
+    #[test]
+    #[should_panic(expected = "could not get balance")]
+    fn balance_of_expect_works() {
+        // Given
+        let env = Env::default();
+        let contract_id = env.register_contract(None, UnsafeExpect);
+        let client = UnsafeExpectClient::new(&env, &contract_id);
+
+        // When - Balance not set
+
+        // Then
+        let _balance = client.balance_of(&contract_id);
+
+        // Test should panic
+    }
 }

--- a/test-cases/unsafe-expect/unsafe-expect-5/vulnerable-example/src/lib.rs
+++ b/test-cases/unsafe-expect/unsafe-expect-5/vulnerable-example/src/lib.rs
@@ -69,4 +69,20 @@ mod tests {
         // Then
         assert_eq!(TOTAL_SUPPLY + 2, balances.unwrap());
     }
+
+    #[test]
+    #[should_panic(expected = "could not get balance")]
+    fn balance_of_expect_works() {
+        // Given
+        let env = Env::default();
+        let contract_id = env.register_contract(None, UnsafeExpect);
+        let client = UnsafeExpectClient::new(&env, &contract_id);
+
+        // When - Balance not set
+
+        // Then
+        let _balance = client.balance_add(&contract_id);
+
+        // Test should panic
+    }
 }


### PR DESCRIPTION
Some tests were removed due to aborting instead of unwinding panic's. This is due to rust's nightly behaviour, and does not happen on stable builds.